### PR TITLE
Fix resource handling on 5e system versions 1.5.7 and below

### DIFF
--- a/scripts/libwrapper.js
+++ b/scripts/libwrapper.js
@@ -341,7 +341,7 @@ function patch_getUsageUpdates(){
             const id = this.data.data;
             const actorUpdates = {};
             const itemUpdates = {};
-            const resourceUpdates = isNewerVersion("1.5.7", game.system.data.version) ? {} : [];
+            const resourceUpdates = isNewerVersion(game.system.data.version, "1.5.7") ? [] : {};
 
             // Consume Recharge
             if ( consumeRecharge ) {


### PR DESCRIPTION
This fixes resource handling for versions 1.5.7 and below of the 5e system.

The [previous fix](https://github.com/fantasycalendar/FoundryVTT-RestRecovery/blame/2cc62c2d63f198a9138c9011cc4e02cf4c4f4694/scripts/libwrapper.js#L338) didn't actually end up doing anything when the system version was exactly "1.5.7", as `isNewerVersion` performs a greater-than comparison, not greater-than-or-equal.

The new fix can be read as "if the system version is greater than 1.5.7, use an array, otherwise use an object".