### PR TITLE
fix: Short Rest button unresponsive with custom hit dice formula

### DIFF
--- a/scripts/apps/rest.js
+++ b/scripts/apps/rest.js
@@ -63,7 +63,7 @@ export class RestApplication extends HandlebarsApplicationMixin(ApplicationV2) {
     let maxSpendHitDice;
     const maxHitDiceSpendMultiplier = determineMultiplier(CONSTANTS.SETTINGS.MAX_HIT_DICE_SPEND);
     if (typeof maxHitDiceSpendMultiplier === "string") {
-      const rollFormula = Roll.replaceFormulaData(maxHitDiceSpendMultiplier, data, { warn: true });
+      const rollFormula = Roll.replaceFormulaData(maxHitDiceSpendMultiplier, this.actor.getRollData(), { warn: true });
       maxSpendHitDice = Math.floor(new Roll(rollFormula).evaluateSync({ strict: false }).total);
     } else {
       maxSpendHitDice = Math.floor(this.actor.system.attributes.hd.max * maxHitDiceSpendMultiplier);


### PR DESCRIPTION
When a custom formula was set for "Maximum short rest hit die spend", the Short Rest and Long Rest buttons would become unresponsive.

The issue stemmed from an `undefined` variable being passed to `Roll.replaceFormulaData` within the `RestApplication` constructor during its initialization. This prevented the correct evaluation of the custom formula, leading to a breakdown in the rest workflow.

This commit resolves the problem by ensuring that `this.actor.getRollData()` is correctly passed to `Roll.replaceFormulaData`, allowing custom hit dice formulas to be evaluated properly and restoring the functionality of the rest buttons.