### PR TITLE
bug-fix: Long rest bug using buffered short rest

### DIFF
--- a/scripts/rest-workflow.js
+++ b/scripts/rest-workflow.js
@@ -186,8 +186,6 @@ export default class RestWorkflow {
       if ((bufferDice ?? 0) > 0) {
         delete updates.class["system.hd.spent"];
         updates.class[CONSTANTS.FLAGS.HIT_DICE_BUFFER_FLAG] = bufferDice - 1;
-      } else if (bufferDice === 0) {
-        updates.class[`-=${CONSTANTS.FLAGS.HIT_DICE_BUFFER_FLAG}`] = null;
       }
 
     });


### PR DESCRIPTION
Console Error:
```
Removing a key using the -= deletion syntax requires the value of that deletion key to be null, for example {-=key: null}
```

Stack Trace:
```js
[Detected 2 packages: system:dnd5e(5.2.4), rest-recovery(AUTOMATIC)]
    at SchemaField._updateDiff (foundry.mjs:8431:35)
    at Item5e.updateSource (foundry.mjs:11810:17)
    at #preUpdateDocumentArray (foundry.mjs:58750:20)
    at async ClientDatabaseBackend._updateDocuments (foundry.mjs:58692:5)
    at async Item5e.updateDocuments (foundry.mjs:12555:21)
    at async Item5e.update (foundry.mjs:12667:21)
    at async Actor5e.rollHitDie (actor.mjs:1960:50)
    at async _RestWorkflow.rollHitDice (rest-workflow.js:748:18)
    at async _RestApplication.rollHitDice (rest.js:355:20)
    at async #onRollHitDie (rest.js:351:5)
```

Problem:
R&R rest-workflow.js line 190 was attempting to push an update to tell Foundry to remove the HIT_DICE_BUFFER_FLAG but this is already handled by lines 1420-1423
```js
lib.addToUpdates(results.updateItems, {
          _id: cls.id,
          [CONSTANTS.FLAGS.REMOVE_HIT_DICE_BUFFER_FLAG]: null
        });
```

Solution:
Only decrement the flag to 0. The code handles all integer values of the flag during the long rest fine. The code also handles cleanup after the long rest fine. No need to try to delete it before the long rest is over.

Tested:
 * Recreated error using reporters settings
 * Applied fix
 * Inspected flags during and after long rest
 * Verified no error and correct functionality when hitDiceBuffer expended and depleted.
 * Verified no error and correct functionality when ending with positive hitDiceBuffer.

Bug-Id: 342
Signed-off-by: aljames-arctic <bakanabaka.vtt@gmail.com>