### PR TITLE
Fire dnd5e rest hook for group actors before advancing time

### DIFF
--- a/scripts/apps/promptRest.js
+++ b/scripts/apps/promptRest.js
@@ -153,15 +153,20 @@ export class PromptRestApplication extends HandlebarsApplicationMixin(Applicatio
     await this.updateRestConfig(false);
     const timeChanges = getTimeChanges(restType === "long");
 
-    if (getSetting(CONSTANTS.SETTINGS.ENABLE_PROMPT_REST_TIME_PASSING)) {
+    const trueNewDay = this.useCalendar ? timeChanges.isNewDay : this.forceNewDay;
+    if (this.groupActor) {
+      const hookConfig = { type: restType, newDay: trueNewDay, advanceTime: true, duration: timeChanges.restTime / 60 };
+      Hooks.call(`dnd5e.${restType}Rest`, this.groupActor, hookConfig);
+      if (!hookConfig.advanceTime) timeChanges.restTime = 0;
+    }
+
+    if (getSetting(CONSTANTS.SETTINGS.ENABLE_PROMPT_REST_TIME_PASSING) && timeChanges.restTime > 0) {
       await game.time.advance(timeChanges.restTime);
     }
 
     if (this.advanceBastionTurn) {
       await dnd5e.bastion.advanceAllBastions();
     }
-
-    const trueNewDay = this.useCalendar ? timeChanges.isNewDay : this.forceNewDay;
 
     if (this.configuration.size) {
       const restConfig = CONFIG.DND5E.restTypes[restType];


### PR DESCRIPTION
- Call Hooks.call(`dnd5e.${restType}Rest`) for the group actor in PromptRestApplication.doRest() before time advancement
- Respect config.advanceTime if a hook handler sets it to false, skipping game.time.advance()
- Matches the pattern already used for individual actors in the preLongRest handler

Closes #351